### PR TITLE
pants: upgrade Pants to 2.18.1

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.17.0"
+pants_version = "2.18.1"
 backend_packages = [
   # This repository demonstrates using Pants with Kotlin.
   #

--- a/tests/jvm/org/pantsbuild/example/lib/BUILD
+++ b/tests/jvm/org/pantsbuild/example/lib/BUILD
@@ -1,5 +1,5 @@
 kotlin_junit_tests(
     # These tests are `parametrize`d, so that they will run against two different
     # JDK versions.
-    jdk=parametrize(adopt_11="adopt:1.11", adopt_12="adopt:1.12.0.2"),
+    jdk=parametrize(temurin_11="temurin:1.11", temurin_17="temurin:1.17"),
 )


### PR DESCRIPTION
Upgrade to 2.18.1 and start using Apple silicon compatible JDK.